### PR TITLE
Remove /userinfo audience

### DIFF
--- a/01-Login/server.py
+++ b/01-Login/server.py
@@ -27,8 +27,6 @@ AUTH0_CLIENT_SECRET = env.get(constants.AUTH0_CLIENT_SECRET)
 AUTH0_DOMAIN = env.get(constants.AUTH0_DOMAIN)
 AUTH0_BASE_URL = 'https://' + AUTH0_DOMAIN
 AUTH0_AUDIENCE = env.get(constants.AUTH0_AUDIENCE)
-if AUTH0_AUDIENCE is '':
-    AUTH0_AUDIENCE = AUTH0_BASE_URL + '/userinfo'
 
 app = Flask(__name__, static_url_path='/public', static_folder='./public')
 app.secret_key = constants.SECRET_KEY


### PR DESCRIPTION
Removed unnecessary `/userinfo` audience from authorization parameters if no API audience is requested.